### PR TITLE
Multiply memory fix

### DIFF
--- a/sparse.cabal
+++ b/sparse.cabal
@@ -60,7 +60,7 @@ library
   build-depends:
     base              >= 4     && < 5,
     contravariant     >= 1     && < 2,
-    deepseq           >= 1.1   && < 1.4,
+    deepseq           >= 1.1   && < 1.5,
     hybrid-vectors    >= 0.1   && < 1,
     lens              >= 4     && < 5,
     primitive         >= 0.5   && < 0.6,

--- a/sparse.cabal
+++ b/sparse.cabal
@@ -61,12 +61,12 @@ library
     base              >= 4     && < 5,
     contravariant     >= 1     && < 2,
     deepseq           >= 1.1   && < 1.5,
-    hybrid-vectors    >= 0.1   && < 1,
+    hybrid-vectors    >= 0.2   && < 3,
     lens              >= 4     && < 5,
     primitive         >= 0.5   && < 0.6,
     transformers      >= 0.3   && < 0.5,
     vector            >= 0.10  && < 0.11,
-    vector-algorithms >= 0.5   && < 0.7
+    vector-algorithms >= 0.5   && < 0.8
 
   hs-source-dirs: src
 

--- a/src/Sparse/Matrix.hs
+++ b/src/Sparse/Matrix.hs
@@ -336,14 +336,15 @@ multiplyWith :: Arrayed a => (a -> a -> a) -> (Maybe (Heap a) -> Stream (Key, a)
 multiplyWith times make x0 y0 = case compare (size x0) 1 of
   LT -> empty
   EQ | size y0 == 0 -> empty
-     | size y0 == 1 -> hinted $ go11 (lo x0) (head x0) (lo y0) (head y0)
-     | otherwise    -> hinted $ go12 (lo x0) (head x0) (lo y0) y0 (hi y0)
+     | size y0 == 1 -> unhinted $ go11 (lo x0) (head x0) (lo y0) (head y0)
+     | otherwise    -> unhinted $ go12 (lo x0) (head x0) (lo y0) y0 (hi y0)
   GT -> case compare (size y0) 1 of
       LT -> empty
-      EQ -> hinted $ go21 (lo x0) x0 (hi x0) (lo y0) (head y0)
-      GT -> hinted $ go22 (lo x0) x0 (hi x0) (lo y0) y0 (hi y0)
+      EQ -> unhinted $ go21 (lo x0) x0 (hi x0) (lo y0) (head y0)
+      GT -> unhinted $ go22 (lo x0) x0 (hi x0) (lo y0) y0 (hi y0)
   where
-    hinted x = _Mat # G.unstream (sized (make x) (Max (size x0 * size y0)))
+    -- hinted x = _Mat # G.unstream (sized (make x) (Max (size x0 * size y0)))
+    unhinted x = _Mat # G.unstream (make x)
 
     go11 (Key i j) a (Key j' k) b
        | j == j' = Just $ Heap.singleton (Key i k) (times a b)


### PR DESCRIPTION
@ekmett correctly identified `G.unstream` to be preallocating the maximum size of vector `multiplyWith` could result in as defined by the `hinted` function. Removing the `Max` size hint solves this memory allocation problem.

Before, multiplying a 70 x 16000 matrix `D` with 40559 non-zero elements with `transpose D` resulted in 13160677376 bytes (13160259848 == 40559^2  \* 8) being allocated. This is unnecessary since at most we expect `D * transpose D` to result in a 70 x 70 matrix with 4900 elements.

Also bumped some package versions.
